### PR TITLE
Add partial compare filter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
     "editor.codeActionsOnSave": {
         "source.fixAll": true
+    },
+    "[markdown]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
     }
 }

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This package provides a number of functions that can be passed into [Array.proto
 1. [Compose](#compose)
 1. [Equality](#equality)
 1. [Number](#number)
+1. [Object](#object)
 1. [String](#string)
 1. [Deduplication](#deduplication)
 
@@ -71,6 +72,25 @@ Each function uses currying to pass down a value to check against, making usage 
 ```ts
 [1, 2, 3, 4].filter(lessThan(3));
 // returns [1, 2]
+```
+
+## Object
+
+This includes filters for lists of objects or data structures.
+
+### where
+
+`where` allows you to pass a partial representation of the objects contained in the array, much like a query, returning objects that have the given properties with the given values.
+
+```ts
+const a = { x: 1, y: { nested: { property: 'hello' } } };
+const b = { x: 1, y: { nested: { property: 'goodbye' } } };
+
+[a, b].filter(where({ x: 1 }));
+// returns [a, b]
+
+[a, b].filter(where({ y: { nested: { property: 'goodbye' } } }));
+// returns [b]
 ```
 
 ## String

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-filters",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-filters",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "devDependencies": {
         "@types/jest": "^26.0.22",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "ts-filters",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Composable filters for arrays in TypeScript",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "files": ["lib/**/*"],
+  "files": [
+    "lib/**/*"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "jest"

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,6 @@ export * from './compose';
 export * from './equality';
 export * from './models';
 export * from './number';
+export * from './object';
 export * from './string';
 export * from './unique';

--- a/src/models/DeepPartial.ts
+++ b/src/models/DeepPartial.ts
@@ -1,0 +1,3 @@
+export type DeepPartial<T> = {
+    [Property in keyof T]?: DeepPartial<T[Property]>
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,3 +1,4 @@
 export * from './Comparer';
+export * from './DeepPartial';
 export * from './Predicate';
 export * from './Primitive';

--- a/src/object/index.ts
+++ b/src/object/index.ts
@@ -1,0 +1,1 @@
+export * from './where';

--- a/src/object/where.ts
+++ b/src/object/where.ts
@@ -1,4 +1,4 @@
-import { DeepPartial } from '../models/DeepPartial';
+import { DeepPartial } from '../models';
 import { comparePartial } from '../util/comparePartial';
 
 export const where =

--- a/src/object/where.ts
+++ b/src/object/where.ts
@@ -1,0 +1,7 @@
+import { DeepPartial } from '../models/DeepPartial';
+import { comparePartial } from '../util/comparePartial';
+
+export const where =
+  <T extends object>(properties: DeepPartial<T>) =>
+  (item: T) =>
+    comparePartial(properties, item);

--- a/src/object/where.ts
+++ b/src/object/where.ts
@@ -1,6 +1,22 @@
 import { DeepPartial } from '../models';
 import { comparePartial } from '../util/comparePartial';
 
+/**
+ *
+ * @param properties A partial representation of the interface the objects
+ * in the list conform to, to act as a query.
+ * @example
+ * ```ts
+ * const a = { x: 1, y: { nested: { property: 'hello' } } };
+ * const b = { x: 1, y: { nested: { property: 'goodbye' } } };
+ * 
+ * [a, b].filter(where({ x: 1 }));
+ * // returns [a, b]
+ * 
+ * [a, b].filter(where({ y: { nested: { property: 'goodbye' } } }));
+ * // returns [b]
+```
+ */
 export const where =
   <T extends object>(properties: DeepPartial<T>) =>
   (item: T) =>

--- a/src/util/comparePartial.ts
+++ b/src/util/comparePartial.ts
@@ -1,4 +1,4 @@
-import { DeepPartial } from '../models/DeepPartial';
+import { DeepPartial } from '../models';
 import { isPrimitiveOrNull } from './isPrimitiveOrNull';
 import { objectKeys } from './objectKeys';
 

--- a/src/util/comparePartial.ts
+++ b/src/util/comparePartial.ts
@@ -1,0 +1,17 @@
+import { DeepPartial } from '../models/DeepPartial';
+import { isPrimitiveOrNull } from './isPrimitiveOrNull';
+import { objectKeys } from './objectKeys';
+
+export const comparePartial = <T extends {}>(
+  a: DeepPartial<T>,
+  b: T
+): boolean => {
+  return objectKeys(a).every((key) => {
+    const valueA = a[key];
+    const valueB = b[key];
+    if (isPrimitiveOrNull(valueA) || !valueA) {
+      return valueA === valueB;
+    }
+    return comparePartial(valueA!, valueB);
+  });
+};

--- a/test/object/where.test.ts
+++ b/test/object/where.test.ts
@@ -1,0 +1,44 @@
+import { where } from '../../src';
+
+describe(where.name, () => {
+  interface MyMock {
+    my: {
+      nested: {
+        property: {
+          x: number;
+          y: number;
+        };
+      };
+    };
+  }
+
+  const createMock = (x: number, y: number): MyMock => ({
+    my: {
+      nested: {
+        property: {
+          x,
+          y,
+        },
+      },
+    },
+  });
+
+  it('Filters out items that do not match the given partial', () => {
+    const a = createMock(1, 2);
+    const b = createMock(1, 3);
+    const c = createMock(2, 2);
+
+    const result = [a, b, c].filter(
+      where({
+        my: {
+          nested: {
+            property: {
+              y: 2,
+            },
+          },
+        },
+      })
+    );
+    expect(result).toEqual([a, c]);
+  });
+});

--- a/test/util/comparePartial.test.ts
+++ b/test/util/comparePartial.test.ts
@@ -1,0 +1,15 @@
+import { comparePartial } from '../../src/util/comparePartial';
+
+describe(comparePartial.name, () => {
+  it('Returns true if properties common to both match', () => {
+    const a = { my: { nested: { property: { x: 1 } } } };
+    const b = { my: { nested: { property: { x: 1, y: 1 } } } };
+    expect(comparePartial(a, b)).toBe(true);
+  });
+
+  it('Returns false if properties common to both do not match', () => {
+    const a = { my: { nested: { property: { x: 2 } } } };
+    const b = { my: { nested: { property: { x: 1, y: 1 } } } };
+    expect(comparePartial(a, b)).toBe(false);
+  });
+});


### PR DESCRIPTION
This adds a `where` function that can be used in conjunction with `.filter` to filter lists of objects based a partial representation, usage is shown in the README and TSDoc.